### PR TITLE
pin R version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # start from shiny-verse to include both the shiny and tidyverse packages,
 # saving us time assuming that the app to be deployed doesn't have dependencies
 # locked to different versions.
-FROM rocker/shiny-verse:latest
+FROM rocker/shiny-verse:4.5.0
 
 # install rsconnect and renv packages, as well as prerequisite libraries
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
pin R to 4.5.0, which is the latest version currently supported on shinyapps.io. `latest` keeps pulling from the latest version, which is not always supported on shinyapps.io